### PR TITLE
Save entity methods

### DIFF
--- a/CRM/Wrapi/Actions/Create.php
+++ b/CRM/Wrapi/Actions/Create.php
@@ -40,45 +40,6 @@ class CRM_Wrapi_Actions_Create
     }
 
     /**
-     * Add email to contact
-     *
-     * @deprecated
-     *
-     * @param string $email Email address
-     * @param int $contact_id Contact ID
-     * @param string $type Email address type
-     *  'Home'
-     *  'Work'
-     *  'Main'
-     *  'Billing'
-     *  'Other'
-     * @param bool $check_permissions Should we check permissions (ACLs)?
-     *
-     * @return int Email ID
-     *
-     * @throws API_Exception
-     * @throws UnauthorizedException
-     * @throws CRM_Core_Exception
-     */
-    public static function emailToContact(
-        string $email,
-        int $contact_id,
-        string $type = 'Home',
-        bool $check_permissions = false
-    ): int {
-        CRM_Wrapi_Processor_Base::validateInput($email, 'string', 'Email address');
-        CRM_Wrapi_Processor_Base::validateInput($contact_id, 'id', 'Contact ID');
-
-        $results = Email::create($check_permissions)
-            ->addValue('contact_id', $contact_id)
-            ->addValue('email', $email)
-            ->addValue('location_type_id:name', $type)
-            ->execute();
-
-        return self::parseResults($results, 'add email to contact');
-    }
-
-    /**
      * Add new generic entity
      *
      * @param string $entity Name of entity

--- a/CRM/Wrapi/Actions/Get.php
+++ b/CRM/Wrapi/Actions/Get.php
@@ -34,7 +34,7 @@ class CRM_Wrapi_Actions_Get
     {
         $results = Email::get($check_permissions)
             ->addSelect('contact_id')
-            ->addWhere('email', 'LIKE', $email)
+            ->addWhere('email', '=', $email)
             ->setLimit(1)
             ->execute();
 

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -415,29 +415,9 @@ abstract class CRM_Wrapi_Handler_Base
             throw new CRM_Core_Exception('External ID missing');
         }
 
-        // Retrieve contact ID
         $contact_id = CRM_Wrapi_Actions_Get::contactIDFromExternalID($external_id);
 
-        // Save Contact entity
-        // If contact ID is null here, it is not a problem, a contact will be created
-        // If contact ID is not null it won't change (hopefully :))
-        $contact_id = $this->saveContact($contact_id, $record['contact']);
-
-        // At this point now there must be a contact ID
-        if (is_null($contact_id)) {
-            throw new CRM_Core_Exception('Failed to retrieve contact');
-        }
-
-        // Save related entities
-        $this->saveEmail($contact_id, $record['email']);
-        $this->savePhone($contact_id, $record['phone']);
-        $this->saveAddress($contact_id, $record['address']);
-
-        foreach ($record['relationship'] as $relationship_data) {
-            $this->saveRelationship($contact_id, $relationship_data);
-        }
-
-        return $contact_id;
+        return $this->saveContact($contact_id, $record);
     }
 
     /**

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -443,7 +443,7 @@ abstract class CRM_Wrapi_Handler_Base
      * If not then create new contact
      *
      * @param int|null $contact_id Contact ID
-     * @param array $contact_data Contact data
+     * @param array|null $contact_data Contact data
      *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
      *   See Api Explorer v4
      *
@@ -453,7 +453,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws CRM_Core_Exception
      * @throws NotImplementedException
      */
-    protected function saveContact(?int $contact_id, array $contact_data): ?int
+    protected function saveContact(?int $contact_id, ?array $contact_data): ?int
     {
         if (empty($contact_data)) {
             return null;
@@ -480,7 +480,7 @@ abstract class CRM_Wrapi_Handler_Base
      * If not present then add new email
      *
      * @param int $contact_id Contact ID
-     * @param array $email_data Email data
+     * @param array|null $email_data Email data
      *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
      *   See Api Explorer v4
      *
@@ -498,7 +498,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveEmail(int $contact_id, array $email_data): ?int
+    protected function saveEmail(int $contact_id, ?array $email_data): ?int
     {
         if (empty($email_data)) {
             return null;
@@ -528,7 +528,7 @@ abstract class CRM_Wrapi_Handler_Base
      * If not present then add new number
      *
      * @param int $contact_id Contact ID
-     * @param array $phone_data Phone data
+     * @param array|null $phone_data Phone data
      *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
      *   See Api Explorer v4
      *
@@ -546,7 +546,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function savePhone(int $contact_id, array $phone_data): ?int
+    protected function savePhone(int $contact_id, ?array $phone_data): ?int
     {
         if (empty($phone_data)) {
             return null;
@@ -576,7 +576,7 @@ abstract class CRM_Wrapi_Handler_Base
      * If not present then add new address
      *
      * @param int $contact_id Contact ID
-     * @param array $address_data Address data
+     * @param array|null $address_data Address data
      *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
      *   See Api Explorer v4
      *
@@ -594,7 +594,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveAddress(int $contact_id, array $address_data): ?int
+    protected function saveAddress(int $contact_id, ?array $address_data): ?int
     {
         if (empty($address_data)) {
             return null;
@@ -624,7 +624,7 @@ abstract class CRM_Wrapi_Handler_Base
      * If not present then add new relationship
      *
      * @param int $contact_id Contact ID
-     * @param array $relationship_data Relationship data
+     * @param array|null $relationship_data Relationship data
      *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
      *   See Api Explorer v4
      *
@@ -643,7 +643,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveRelationship(int $contact_id, array $relationship_data): ?int
+    protected function saveRelationship(int $contact_id, ?array $relationship_data): ?int
     {
         if (empty($relationship_data)) {
             return null;

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -384,7 +384,7 @@ abstract class CRM_Wrapi_Handler_Base
      *         'last_name' => 'Doe',
      *         'contact_type' => 'Individual',
      *         'external_identifier' => '1234',
-     *         'job_title' => 'The Big Boss',
+     *         'job_title' => 'Big Boss',
      *       ],
      *       'email' => [
      *         'email' => 'john@big.corp',
@@ -502,7 +502,7 @@ abstract class CRM_Wrapi_Handler_Base
      *   Example:
      *   $contact_data = [
      *     'first_name' => 'Janos',
-     *     'job_title' => 'Big Boss,
+     *     'postal_greeting_id' => '1,
      *     'preferred_language' => 'hu_HU',
      *   ];
      *

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -491,15 +491,17 @@ abstract class CRM_Wrapi_Handler_Base
      *     'signature_text' => 'Regards',
      *   ];
      *
+     * @return int|null Created Email ID
+     *
      * @throws API_Exception
      * @throws CRM_Core_Exception
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveEmail(int $contact_id, array $email_data)
+    protected function saveEmail(int $contact_id, array $email_data): ?int
     {
         if (empty($email_data)) {
-            return;
+            return null;
         }
 
         // Check for previous email
@@ -515,6 +517,8 @@ abstract class CRM_Wrapi_Handler_Base
             CRM_Wrapi_Actions_Update::email($email_id, $email_data);
             $this->debug(sprintf('Email updated (Email ID: %s)', $email_id));
         }
+
+        return $email_id;
     }
 
     /**
@@ -535,15 +539,17 @@ abstract class CRM_Wrapi_Handler_Base
      *     'phone' => '+3611234567',
      *   ];
      *
+     * @return int|null Created Phone ID
+     *
      * @throws API_Exception
      * @throws CRM_Core_Exception
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function savePhone(int $contact_id, array $phone_data)
+    protected function savePhone(int $contact_id, array $phone_data): ?int
     {
         if (empty($phone_data)) {
-            return;
+            return null;
         }
 
         // Check for previous phone
@@ -559,6 +565,8 @@ abstract class CRM_Wrapi_Handler_Base
             CRM_Wrapi_Actions_Update::phone($phone_id, $phone_data);
             $this->debug(sprintf('Phone updated (Phone ID: %s)', $phone_id));
         }
+
+        return $phone_id;
     }
 
     /**
@@ -579,15 +587,17 @@ abstract class CRM_Wrapi_Handler_Base
      *     'phone' => '+3611234567',
      *   ];
      *
+     * @return int|null Created Address ID
+     *
      * @throws API_Exception
      * @throws CRM_Core_Exception
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveAddress(int $contact_id, array $address_data)
+    protected function saveAddress(int $contact_id, array $address_data): ?int
     {
         if (empty($address_data)) {
-            return;
+            return null;
         }
 
         // Check for previous address
@@ -603,6 +613,8 @@ abstract class CRM_Wrapi_Handler_Base
             CRM_Wrapi_Actions_Update::address($address_id, $address_data);
             $this->debug(sprintf('Address updated (Address ID: %s)', $address_id));
         }
+
+        return $address_id;
     }
 
     /**
@@ -624,15 +636,17 @@ abstract class CRM_Wrapi_Handler_Base
      *     'is_active' => 1,
      *   ];
      *
+     * @return int|null Created relationship ID
+     *
      * @throws API_Exception
      * @throws CRM_Core_Exception
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveRelationship(int $contact_id, array $relationship_data)
+    protected function saveRelationship(int $contact_id, array $relationship_data): ?int
     {
         if (empty($relationship_data)) {
-            return;
+            return null;
         }
 
         // Check for previous relationship
@@ -654,5 +668,7 @@ abstract class CRM_Wrapi_Handler_Base
             CRM_Wrapi_Actions_Update::relationship($relationship_id, $relationship_data);
             $this->debug(sprintf('Relationship updated (Relation ID: %s)', $relationship_id));
         }
+
+        return $relationship_id;
     }
 }

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -363,6 +363,44 @@ abstract class CRM_Wrapi_Handler_Base
      *
      * @param string|null $external_id External ID
      * @param array $record Contact data
+     *   This array is structured by entities. All relevant fields for each entity (contact, email, phone, address,
+     *   relationship) must be in separate arrays and indexed by the entity name. Not all entity have to be in the array,
+     *   say we don't want to save any address, simple don't include data. Also not all fields for a given entity is
+     *   required to be present in the array, only fields that we want to save. However there are required fields
+     *   for each entity (e.g. contact_id, location_type_id for email), but it is not checked here, it should be
+     *   enforced earlier in the validate phase, or leave it to \Civi\Api4 to complain :)
+     *
+     *   Note:
+     *     - There is no need to include contact ID for Email, Phone, etc entities (though they are required by Api4).
+     *       That will be handled by the method.
+     *     - Currently it is not possible to set different types of email, phone, address (main, work, home) in one call.
+     *       If you need to save more emails, you have to call this method again.
+     *     - It is possible to give several relationship in one call, in fact relationship data have to be given in array. See example.
+     *
+     *   Example:
+     *     $record = [
+     *       'contact' => [
+     *         'first_name' => 'John',
+     *         'last_name' => 'Doe',
+     *         'contact_type' => 'Individual',
+     *         'external_identifier' => '1234',
+     *         'job_title' => 'The Big Boss',
+     *       ],
+     *       'email' => [
+     *         'email' => 'john@big.corp',
+     *         'location_type_id' => '1',
+     *       ],
+     *       'relationship' => [
+     *           [
+     *             'contact_id_b' => '145',
+     *             'relationship_type_id' => '1',
+     *           ],
+     *           [
+     *             'contact_id_b' => '111',
+     *             'relationship_type_id' => '2',
+     *           ],
+     *         ],
+     *       ];
      *
      * @throws API_Exception
      * @throws CRM_Core_Exception
@@ -406,8 +444,10 @@ abstract class CRM_Wrapi_Handler_Base
      *
      * @param int|null $contact_id Contact ID
      * @param array $contact_data Contact data
+     *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
+     *   See Api Explorer v4
      *
-     * @return int|null
+     * @return int|null Created contact ID
      *
      * @throws API_Exception
      * @throws CRM_Core_Exception
@@ -441,6 +481,15 @@ abstract class CRM_Wrapi_Handler_Base
      *
      * @param int $contact_id Contact ID
      * @param array $email_data Email data
+     *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
+     *   See Api Explorer v4
+     *
+     *   Example:
+     *   $email_data = [
+     *     'location_type_id' => 1,
+     *     'is_primary' => 0,
+     *     'signature_text' => 'Regards',
+     *   ];
      *
      * @throws API_Exception
      * @throws CRM_Core_Exception
@@ -476,6 +525,15 @@ abstract class CRM_Wrapi_Handler_Base
      *
      * @param int $contact_id Contact ID
      * @param array $phone_data Phone data
+     *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
+     *   See Api Explorer v4
+     *
+     *   Example:
+     *   $phone_data = [
+     *     'location_type_id' => 1,
+     *     'mobile_provider_id' => 3,
+     *     'phone' => '+3611234567',
+     *   ];
      *
      * @throws API_Exception
      * @throws CRM_Core_Exception
@@ -511,6 +569,15 @@ abstract class CRM_Wrapi_Handler_Base
      *
      * @param int $contact_id Contact ID
      * @param array $address_data Address data
+     *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
+     *   See Api Explorer v4
+     *
+     *   Example:
+     *   $address_data = [
+     *     'location_type_id' => 1,
+     *     'mobile_provider_id' => 3,
+     *     'phone' => '+3611234567',
+     *   ];
      *
      * @throws API_Exception
      * @throws CRM_Core_Exception
@@ -546,6 +613,16 @@ abstract class CRM_Wrapi_Handler_Base
      *
      * @param int $contact_id Contact ID
      * @param array $relationship_data Relationship data
+     *   This contains the fields to save, it should be in a format which can be fed to civicrm_api4() calls.
+     *   See Api Explorer v4
+     *
+     *   Example:
+     *   $relationship_data = [
+     *     'contact_id_b' => 11,
+     *     'relationship_type_id' => 3,
+     *     'start_date' => '2021-03-05',
+     *     'is_active' => 1,
+     *   ];
      *
      * @throws API_Exception
      * @throws CRM_Core_Exception

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -642,8 +642,8 @@ abstract class CRM_Wrapi_Handler_Base
      *   Example:
      *   $address_data = [
      *     'location_type_id' => 1,
-     *     'mobile_provider_id' => 3,
-     *     'phone' => '+3611234567',
+     *     'street_number' => '25',
+     *     'city' => 'Budapest',
      *   ];
      *
      * @return int|null Created Address ID

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -402,12 +402,14 @@ abstract class CRM_Wrapi_Handler_Base
      *         ],
      *       ];
      *
+     * @return int Contact ID
+     *
      * @throws API_Exception
      * @throws CRM_Core_Exception
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveContactByExternalID(?string $external_id, array $record)
+    protected function saveContactByExternalID(?string $external_id, array $record): int
     {
         if (empty($external_id)) {
             throw new CRM_Core_Exception('External ID missing');
@@ -434,6 +436,8 @@ abstract class CRM_Wrapi_Handler_Base
         foreach ($record['relationship'] as $relationship_data) {
             $this->saveRelationship($contact_id, $relationship_data);
         }
+
+        return $contact_id;
     }
 
     /**

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -73,6 +73,25 @@ abstract class CRM_Wrapi_Handler_Base
     }
 
     /**
+     * Process Request
+     */
+    abstract protected function process();
+
+    /**
+     * Return request parameter rules
+     *
+     * @return array Input rules
+     *
+     * Properties:
+     *   - type:     Type of field (string | email | int | id | float | bool | date | datetime | list)
+     *   - name:     Name of field
+     *   - required: Is required field (true | false)
+     *   - default:  Default value
+     *   - elements: Definition for list elements (only for list type)
+     */
+    abstract protected function inputRules(): array;
+
+    /**
      * Handle request
      *
      * @return mixed
@@ -331,23 +350,4 @@ abstract class CRM_Wrapi_Handler_Base
 
         return $mapped_data;
     }
-
-    /**
-     * Process Request
-     */
-    abstract protected function process();
-
-    /**
-     * Return request parameter rules
-     *
-     * @return array Input rules
-     *
-     * Properties:
-     *   - type:     Type of field (string | email | int | id | float | bool | date | datetime | list)
-     *   - name:     Name of field
-     *   - required: Is required field (true | false)
-     *   - default:  Default value
-     *   - elements: Definition for list elements (only for list type)
-     */
-    abstract protected function inputRules(): array;
 }

--- a/CRM/Wrapi/Handler/Base.php
+++ b/CRM/Wrapi/Handler/Base.php
@@ -457,7 +457,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws CRM_Core_Exception
      * @throws NotImplementedException
      */
-    protected function saveContact(?int $contact_id, ?array $contact_data): ?int
+    protected function saveContactEntity(?int $contact_id, ?array $contact_data): ?int
     {
         if (empty($contact_data)) {
             return null;
@@ -502,7 +502,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveEmail(int $contact_id, ?array $email_data): ?int
+    protected function saveEmailEntity(int $contact_id, ?array $email_data): ?int
     {
         if (empty($email_data)) {
             return null;
@@ -550,7 +550,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function savePhone(int $contact_id, ?array $phone_data): ?int
+    protected function savePhoneEntity(int $contact_id, ?array $phone_data): ?int
     {
         if (empty($phone_data)) {
             return null;
@@ -598,7 +598,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveAddress(int $contact_id, ?array $address_data): ?int
+    protected function saveAddressEntity(int $contact_id, ?array $address_data): ?int
     {
         if (empty($address_data)) {
             return null;
@@ -647,7 +647,7 @@ abstract class CRM_Wrapi_Handler_Base
      * @throws NotImplementedException
      * @throws UnauthorizedException
      */
-    protected function saveRelationship(int $contact_id, ?array $relationship_data): ?int
+    protected function saveRelationshipEntity(int $contact_id, ?array $relationship_data): ?int
     {
         if (empty($relationship_data)) {
             return null;

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) 
 install it with the command-line tool [cv](https://github.com/civicrm/cv).
 
 ```bash
-git clone https://gitlab.com/semsey_sandor_civicrm/extensions/wrapi.git
+git clone https://github.com/reflexive-communications/wrapi.git
 cv en wrapi
 ```
 

--- a/info.xml
+++ b/info.xml
@@ -9,11 +9,11 @@
         <email>sandor@es-progress.hu</email>
     </maintainer>
     <urls>
-        <url desc="Main Extension Page">https://gitlab.com/semsey_sandor_civicrm/extensions/wrapi</url>
+        <url desc="Main Extension Page">https://github.com/reflexive-communications/wrapi</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2020-02-04</releaseDate>
-    <version>0.9.2</version>
+    <version>0.10.0</version>
     <develStage>beta</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
Added `saveEntity()` methods from child class.

Mostly a simple copy, though there are some improvements, changes:
- moved abstract methods to the beginning of the class for better structure
- improved doc blocks for better documentation (mainly on the structure of array holding contact data)
- `saveEntity()` methods now return created entity ID
- renamed `saveEntity()` methods
- added `saveContactByEmail()`