### PR TITLE
change default permission for routes

### DIFF
--- a/CRM/Wrapi/Form/Route.php
+++ b/CRM/Wrapi/Form/Route.php
@@ -57,7 +57,7 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
         if (!$this->editMode) {
             $this->_defaults['route_enabled'] = 1;
             $this->_defaults['log_level'] = PEAR_LOG_ERR;
-            $this->_defaults['permissions'] = 'administer CiviCRM';
+            $this->_defaults['permissions'] = 'access CiviCRM';
 
             return $this->_defaults;
         }


### PR DESCRIPTION
currently: "Administer CiviCRM"
new: "Access CiviCRM"

"Administer" is for configs and settings, "Access" is for accessing CiviCRM and backend API, which is better fit for the purposes.