### PR TITLE
Activity API

### DIFF
--- a/CRM/Wrapi/Actions/Update.php
+++ b/CRM/Wrapi/Actions/Update.php
@@ -163,4 +163,22 @@ class CRM_Wrapi_Actions_Update
     ): array {
         return self::entity('Relationship', $relationship_id, $values, $check_permissions);
     }
+
+    /**
+     * Update activity
+     *
+     * @param int $activity_id Activity ID
+     * @param array $values Activity data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Activity data
+     *
+     * @throws API_Exception
+     * @throws CRM_Core_Exception
+     * @throws NotImplementedException
+     */
+    public static function activity(int $activity_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Activity', $activity_id, $values, $check_permissions);
+    }
 }

--- a/CRM/Wrapi/Form/Route.php
+++ b/CRM/Wrapi/Form/Route.php
@@ -262,7 +262,7 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
             // Loop through required options
             $missing_options = [];
             foreach ($required_options as $option) {
-                $pattern = "/$option=\S+/";
+                $pattern = "/^$option=\S+$/m";
 
                 // Check for required option
                 if (!preg_match($pattern, $values['options'])) {

--- a/CRM/Wrapi/Form/Route.php
+++ b/CRM/Wrapi/Form/Route.php
@@ -262,7 +262,7 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
             // Loop through required options
             $missing_options = [];
             foreach ($required_options as $option) {
-                $pattern = "/^$option=\S+$/m";
+                $pattern = "/^${option}=\S+$/m";
 
                 // Check for required option
                 if (!preg_match($pattern, $values['options'])) {

--- a/info.xml
+++ b/info.xml
@@ -10,10 +10,12 @@
     </maintainer>
     <urls>
         <url desc="Main Extension Page">https://github.com/reflexive-communications/wrapi</url>
+        <url desc="Documentation">https://github.com/reflexive-communications/wrapi</url>
+        <url desc="Support">https://github.com/reflexive-communications/wrapi/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2020-02-04</releaseDate>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
     <develStage>beta</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
API calls to handle `activity` entity

Minor extra change:
Improve Form validation when editing routes.
Previously required options was validated even it was only a substring of a supplied option.

Example:
Required option: "ad_activity_type"
Supplied option: "new_ad_activity_type"

Now they have to be exactly the same.