### PR TITLE
Current handlers from hook

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+<IfModule mod_rewrite.c>
+    RewriteCond %{REQUEST_URI} !/external/wrapi.php$
+    RewriteRule "^(.+/.*|autoload)\.php($|/)" - [F]
+</IfModule>

--- a/CRM/Wrapi/Form/Route.php
+++ b/CRM/Wrapi/Form/Route.php
@@ -91,6 +91,34 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
     }
 
     /**
+     * Get available handlers
+     * Return defaults plus additional handlers registered by extensions
+     *
+     * @return array Handlers
+     */
+    public function getHandlers(): array
+    {
+        $handlers = [];
+
+        // Fire hook event
+        Civi::dispatcher()->dispatch(
+            "hook_civicrm_wrapiHandlers",
+            Civi\Core\Event\GenericHookEvent::create(
+                [
+                    "options" => &$handlers,
+                ]
+            )
+        );
+
+        // Default handlers
+        $handlers["CRM_Wrapi_Handler_Echo"] = "Wrapi - Echo";
+        $handlers["CRM_Wrapi_Handler_Noop"] = "Wrapi - Noop";
+        $handlers["CRM_Wrapi_Handler_NewTransaction"] = "Wrapi - New Transaction";
+
+        return $handlers;
+    }
+
+    /**
      * Build form
      *
      * @throws CRM_Core_Exception
@@ -104,7 +132,15 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
         $this->add('hidden', 'route_enabled');
         $this->add('text', 'name', ts('Route Name'), [], true);
         $this->add('text', 'selector', ts('Selector'), [], true);
-        $this->add('text', 'handler_class', ts('Handler Class'), [], true);
+        $this->addSelect(
+            'handler_class',
+            [
+                'label' => ts('Handler'),
+                'options' => $this->getHandlers(),
+                'entity' => '',
+            ],
+            true
+        );
         $this->add('textarea', 'options', ts('Options'), ['rows' => 5]);
         $this->addSelect(
             'permissions',

--- a/CRM/Wrapi/Form/Route.php
+++ b/CRM/Wrapi/Form/Route.php
@@ -19,6 +19,41 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
     protected $editMode;
 
     /**
+     * Currently registered handlers
+     *
+     * @var array
+     */
+    protected $registeredHandlers;
+
+    /**
+     * Get available handlers
+     * Return defaults plus additional handlers registered by extensions
+     *
+     * @return array Handlers
+     */
+    public function getHandlers(): array
+    {
+        $handlers = [];
+
+        // Fire hook event
+        Civi::dispatcher()->dispatch(
+            "hook_civicrm_wrapiHandlers",
+            Civi\Core\Event\GenericHookEvent::create(
+                [
+                    "options" => &$handlers,
+                ]
+            )
+        );
+
+        // Default handlers
+        $handlers["CRM_Wrapi_Handler_Echo"] = "Wrapi - Echo";
+        $handlers["CRM_Wrapi_Handler_Noop"] = "Wrapi - Noop";
+        $handlers["CRM_Wrapi_Handler_NewTransaction"] = "Wrapi - New Transaction";
+
+        return $handlers;
+    }
+
+    /**
      * Preprocess form
      *
      * @throws CRM_Core_Exception
@@ -39,6 +74,9 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
             // No valid ID in form or request--> add mode
             $this->editMode = false;
         }
+
+        // Get registered handlers
+        $this->registeredHandlers = $this->getHandlers();
     }
 
     /**
@@ -91,34 +129,6 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
     }
 
     /**
-     * Get available handlers
-     * Return defaults plus additional handlers registered by extensions
-     *
-     * @return array Handlers
-     */
-    public function getHandlers(): array
-    {
-        $handlers = [];
-
-        // Fire hook event
-        Civi::dispatcher()->dispatch(
-            "hook_civicrm_wrapiHandlers",
-            Civi\Core\Event\GenericHookEvent::create(
-                [
-                    "options" => &$handlers,
-                ]
-            )
-        );
-
-        // Default handlers
-        $handlers["CRM_Wrapi_Handler_Echo"] = "Wrapi - Echo";
-        $handlers["CRM_Wrapi_Handler_Noop"] = "Wrapi - Noop";
-        $handlers["CRM_Wrapi_Handler_NewTransaction"] = "Wrapi - New Transaction";
-
-        return $handlers;
-    }
-
-    /**
      * Build form
      *
      * @throws CRM_Core_Exception
@@ -136,7 +146,7 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
             'handler_class',
             [
                 'label' => ts('Handler'),
-                'options' => $this->getHandlers(),
+                'options' => $this->registeredHandlers,
                 'entity' => '',
             ],
             true
@@ -276,6 +286,20 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
     protected function validateHandlerAndOptions($values)
     {
         $handler = $values['handler_class'];
+
+        // Check if handler is registered
+        $registered = false;
+        foreach ($this->registeredHandlers as $handler_class => $handler_desc) {
+            if ($handler == $handler_class) {
+                $registered = true;
+                break;
+            }
+        }
+        if (!$registered) {
+            $errors['handler_class'] = ts('Handler: %1 is not registered!', ['1' => $handler,]);
+
+            return $errors;
+        }
 
         // Check if handler class exists
         if (!class_exists($handler)) {

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -1,3 +1,37 @@
 # WrAPI
 
 ## Developer Notes
+
+This guide is intended for developers who wish to extend wrAPI with additional handlers. Handlers can be implemented in
+this extension or - the recommended way - in separate extensions. Basically you need the write the handler then register
+it for wrAPI. After it will be available to select for routes.
+
+### Implementing Handler
+
+The handler should inherit from `CRM_Wrapi_Handler_Base`.
+
+### Registering Handler
+
+The following hook should be implemented:
+
+**Definition**
+`hook_civicrm_wrapiHandlers(&$handlers)`
+
+**Parameters**
+
+- `$handlers` - it contains the handlers
+    ```
+    $handler = [
+      'handler_class_1' => 'handler name #1',
+      'handler_class_2' => 'handler name #2',
+    ];
+    ```
+
+**Example**
+
+```php
+function example_civicrm_wrapiHandlers(&$handlers)
+{
+    $handlers['CRM_Example_Handler_NewHandler']='Your new handler';
+}
+```

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -3,7 +3,7 @@
 ## Developer Notes
 
 This guide is intended for developers who wish to extend wrAPI with additional handlers. Handlers can be implemented in
-this extension or - the recommended way - in separate extensions. Basically you need the write the handler then register
+this extension or - the recommended way - in separate extensions. Basically you need to write the handler then register
 it for wrAPI. After it will be available to select for routes.
 
 ### Implementing Handler

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2020-02-04</releaseDate>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
     <develStage>beta</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,7 +14,7 @@
         <url desc="Support">https://github.com/reflexive-communications/wrapi/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2020-02-04</releaseDate>
+    <releaseDate>2021-03-23</releaseDate>
     <version>0.13.0</version>
     <develStage>beta</develStage>
     <compatibility>


### PR DESCRIPTION
Defines a new hook: `hook_civicrm_wrapiHandlers(&$handlers)`, which can be used by extensions to register new handlers for wrapi.

Also a `.htaccess` file is supplied for the default case, when whitelisting of php files is necessary to allow them accessed by HTTP request.