### PR TITLE
Static gethandlers

### DIFF
--- a/CRM/Wrapi/Form/Route.php
+++ b/CRM/Wrapi/Form/Route.php
@@ -19,19 +19,12 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
     protected $editMode;
 
     /**
-     * Currently registered handlers
-     *
-     * @var array
-     */
-    protected $registeredHandlers;
-
-    /**
      * Get available handlers
      * Return defaults plus additional handlers registered by extensions
      *
      * @return array Handlers
      */
-    public function getHandlers(): array
+    public static function getHandlers(): array
     {
         $handlers = [];
 
@@ -74,9 +67,6 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
             // No valid ID in form or request--> add mode
             $this->editMode = false;
         }
-
-        // Get registered handlers
-        $this->registeredHandlers = $this->getHandlers();
     }
 
     /**
@@ -146,7 +136,7 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
             'handler_class',
             [
                 'label' => ts('Handler'),
-                'options' => $this->registeredHandlers,
+                'options' => self::getHandlers(),
                 'entity' => '',
             ],
             true
@@ -289,7 +279,7 @@ class CRM_Wrapi_Form_Route extends CRM_Wrapi_Form_Base
 
         // Check if handler is registered
         $registered = false;
-        foreach ($this->registeredHandlers as $handler_class => $handler_desc) {
+        foreach (self::getHandlers() as $handler_class => $handler_desc) {
             if ($handler == $handler_class) {
                 $registered = true;
                 break;

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/wrapi/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-03-23</releaseDate>
-    <version>0.13.0</version>
+    <releaseDate>2021-04-01</releaseDate>
+    <version>0.13.1</version>
     <develStage>beta</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
During adding a new route on the UI, after clicking save the form hanged.

After debugging I got the error in the` validateHandlerAndOptions()` function (one of the validating functions added in `addRules()`):
"using $this when not in object context"

So it seems these rules are executed without instantiating the class.

Making the method static solves the problem.